### PR TITLE
[REF] odoo-peru: Standardize odoo-peru project with odoo guidelines.

### DIFF
--- a/l10n_pe_add_series_field/README.rst
+++ b/l10n_pe_add_series_field/README.rst
@@ -1,0 +1,8 @@
+Printer Series Field in Journal
+===============================
+
+
+Printer Series field
+====================
+
+This module add Printer Series Field to Journals.

--- a/l10n_pe_add_series_field/__init__.py
+++ b/l10n_pe_add_series_field/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ###########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_add_series_field/__openerp__.py
+++ b/l10n_pe_add_series_field/__openerp__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 #
 #    Module Writen to OpenERP, Open Source Management Solution
 #
@@ -30,13 +30,8 @@
     'category': 'Vauxoo',
     'depends': ['base', 'account'],
     'author': 'Vauxoo',
-    'description': """
-Printer Series field
-====================
-
-This module add Printer Series Field to Journals.
-    """,
     'website': 'http://www.vauxoo.com',
+    "license": 'AGPL-3',
     'data': [
         'view/account_journal_view.xml'
     ],
@@ -46,5 +41,3 @@ This module add Printer Series Field to Journals.
     'installable': True,
     'auto_install': False
 }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/l10n_pe_add_series_field/model/__init__.py
+++ b/l10n_pe_add_series_field/model/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ###########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_add_series_field/model/journal.py
+++ b/l10n_pe_add_series_field/model/journal.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 #
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_base_vat_split/README.rst
+++ b/l10n_pe_base_vat_split/README.rst
@@ -1,0 +1,7 @@
+VAT Number Split Peru
+=====================
+
+
+This module add Split VAT Number to partner.
+======================================================================
+Split VAT Number to l10n-VAT in a new field calculated

--- a/l10n_pe_base_vat_split/__init__.py
+++ b/l10n_pe_base_vat_split/__init__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# coding: utf-8
 ###########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_base_vat_split/__openerp__.py
+++ b/l10n_pe_base_vat_split/__openerp__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# coding: utf-8
 ###########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #
@@ -29,12 +29,6 @@
     "version": "1.0",
     "author": "Vauxoo",
     "category": "Localization/Peru",
-    "description": """
-This module add Split VAT Number to partner.
-======================================================================
-Split VAT Number to l10n-VAT in a new field calculated
-
-""",
     "website": "http://www.vauxoo.com/",
     "license": "AGPL-3",
     "depends": ["base_vat"],
@@ -42,5 +36,4 @@ Split VAT Number to l10n-VAT in a new field calculated
     "data": [],
     "test": [],
     "installable": True,
-    "active": False,
 }

--- a/l10n_pe_base_vat_split/model/__init__.py
+++ b/l10n_pe_base_vat_split/model/__init__.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# coding: utf-8
 ###########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_base_vat_split/model/base_vat.py
+++ b/l10n_pe_base_vat_split/model/base_vat.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# coding: utf-8
 ###########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #
@@ -44,5 +44,3 @@ class ResPartner(osv.Model):
             string='VAT Split', store=True,
             help='Remove the prefix of the country of the VAT'),
     }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/l10n_pe_crm_lead/README.rst
+++ b/l10n_pe_crm_lead/README.rst
@@ -1,0 +1,6 @@
+Province & District in crm
+==========================
+
+
+        This module add the fields that require the address
+        of partner in the l10n_pe in crm

--- a/l10n_pe_crm_lead/__init__.py
+++ b/l10n_pe_crm_lead/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ###########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_crm_lead/__openerp__.py
+++ b/l10n_pe_crm_lead/__openerp__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ###########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #
@@ -26,14 +26,11 @@
 {
     'name': 'Province & District in crm',
     'version': '1.0',
-    'category': 'Localization\Peru',
+    'category': 'Localization/Peru',
     'depends': ['crm', 'l10n_pe_toponyms'],
     'author': 'Vauxoo',
-    'description': """
-        This module add the fields that require the address
-        of partner in the l10n_pe in crm
-    """,
-    "website": "http://www.vauxoo.com/",
+    'website': 'http://www.vauxoo.com/',
+    'license': 'AGPL-3',
     'data': [
         'view/crm_view.xml',
     ],
@@ -43,5 +40,3 @@
     'installable': True,
     'auto_install': False
 }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/l10n_pe_crm_lead/model/__init__.py
+++ b/l10n_pe_crm_lead/model/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ###########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_crm_lead/model/crm.py
+++ b/l10n_pe_crm_lead/model/crm.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ###########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_crm_lead/wizard/__init__.py
+++ b/l10n_pe_crm_lead/wizard/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ###########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_crm_lead/wizard/crm_lead_to_opportunity.py
+++ b/l10n_pe_crm_lead/wizard/crm_lead_to_opportunity.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ###########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_invoice/README.rst
+++ b/l10n_pe_invoice/README.rst
@@ -1,0 +1,9 @@
+RUC and DNI Validation on Invoice
+=================================
+
+
+Validation for invoice when exceeding minimum amount.
+=========================================================
+
+This module modifies the invoice workflow in order to validate RUC and DNI
+in Invoice that exceeds minimum amount set by configuration wizard.

--- a/l10n_pe_invoice/__init__.py
+++ b/l10n_pe_invoice/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ###########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_invoice/__openerp__.py
+++ b/l10n_pe_invoice/__openerp__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ###########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #
@@ -30,14 +30,8 @@
     'category': 'Invoice Management',
     'depends': ['base', 'account', 'base_vat', 'l10n_pe_multifunctions'],
     'author': 'Vauxoo',
-    'description': """
-Validation for invoice when exceeding minimum amount.
-=========================================================
-
-This module modifies the invoice workflow in order to validate RUC and DNI
-in Invoice that exceeds minimum amount set by configuration wizard.
-    """,
     'website': 'http://www.openerp.com',
+    "license": 'AGPL-3',
     'data': [
         'workflow/invoice_workflow.xml',
         'view/invoice_conf_view.xml',
@@ -50,5 +44,3 @@ in Invoice that exceeds minimum amount set by configuration wizard.
     'installable': True,
     'auto_install': False
 }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/l10n_pe_invoice/model/__init__.py
+++ b/l10n_pe_invoice/model/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ###########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_invoice/model/invoice.py
+++ b/l10n_pe_invoice/model/invoice.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ###########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_invoice/model/invoice_conf_installer.py
+++ b/l10n_pe_invoice/model/invoice_conf_installer.py
@@ -1,4 +1,4 @@
-#    -*- coding: utf-8 -*-
+# coding: utf-8
 ###########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_invoice/model/supplier_invoice_validation.py
+++ b/l10n_pe_invoice/model/supplier_invoice_validation.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ###########################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_multifunctions/README.rst
+++ b/l10n_pe_multifunctions/README.rst
@@ -1,0 +1,8 @@
+Multi Functions Module
+======================
+
+
+Install all apps needed to comply with Peruvian laws
+====================================================
+This module adds validations that will be used in several modules
+of the Peruvian location.

--- a/l10n_pe_multifunctions/__init__.py
+++ b/l10n_pe_multifunctions/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-                                                       #
+# coding: utf-8
 ###############################################################################
 #    Module Writen to OpenERP, Open Source Management Solution                #
 #                                                                             #

--- a/l10n_pe_multifunctions/__openerp__.py
+++ b/l10n_pe_multifunctions/__openerp__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-                                                       #
+# coding: utf-8
 ###############################################################################
 #    Module Writen to OpenERP, Open Source Management Solution                #
 #                                                                             #
@@ -24,16 +24,11 @@
 #                                                                             #
 ###############################################################################
 
-{"name": "Multi Functions Module",
+{
+    "name": "Multi Functions Module",
     "version": "",
     "author": "Vauxoo",
     "category": "Localization/Peru",
-    "description": """
-Install all apps needed to comply with Peruvian laws
-====================================================
-This module adds validations that will be used in several modules
-of the Peruvian location.
-                    """,
     "website": "http://www.vauxoo.com",
     "license": "AGPL-3",
     "depends": ["base", "account"],
@@ -41,4 +36,4 @@ of the Peruvian location.
     "data": [],
     'test': [],
     "installable": True,
-    "active": False, }
+}

--- a/l10n_pe_multifunctions/model/__init__.py
+++ b/l10n_pe_multifunctions/model/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-                                                       #
+# coding: utf-8
 ###############################################################################
 #    Module Writen to OpenERP, Open Source Management Solution                #
 #                                                                             #

--- a/l10n_pe_multifunctions/model/invoice.py
+++ b/l10n_pe_multifunctions/model/invoice.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-                                                       #
+# coding: utf-8
 ###############################################################################
 #    Module Writen to OpenERP, Open Source Management Solution                #
 #                                                                             #

--- a/l10n_pe_toponyms/README.rst
+++ b/l10n_pe_toponyms/README.rst
@@ -1,0 +1,6 @@
+l10n_pe Geopolitical Distribution
+=================================
+
+
+        This module add the fields that require the address of partner in the
+        l10n_pe.

--- a/l10n_pe_toponyms/__init__.py
+++ b/l10n_pe_toponyms/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ##
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_toponyms/__openerp__.py
+++ b/l10n_pe_toponyms/__openerp__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ##
 #    Module Writen to OpenERP, Open Source Management Solution
 #
@@ -26,14 +26,11 @@
 {
     'name': 'l10n_pe Geopolitical Distribution',
     'version': '1.0',
-    'category': 'Localization\Peru',
+    'category': 'Localization/Peru',
     'depends': ['base'],
     'author': 'Vauxoo',
-    'description': """
-        This module add the fields that require the address of partner in the
-        l10n_pe.
-    """,
-    "website": "http://www.vauxoo.com/",
+    'website': 'http://www.vauxoo.com/',
+    "license": 'AGPL-3',
     'data': [
         'security/l10n_pe_security.xml',
         'data/res_country_data.xml',
@@ -49,5 +46,3 @@
     'installable': True,
     'auto_install': False
 }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/l10n_pe_toponyms/model/__init__.py
+++ b/l10n_pe_toponyms/model/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ##
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_toponyms/model/res_company.py
+++ b/l10n_pe_toponyms/model/res_company.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ##
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_toponyms/model/res_partner.py
+++ b/l10n_pe_toponyms/model/res_partner.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ##
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_vat_sunat_validation/README.rst
+++ b/l10n_pe_vat_sunat_validation/README.rst
@@ -1,0 +1,6 @@
+Validation RUC SUNAT 
+=====================
+
+
+This module adds functionality to validate de RUC with SUNAT, and get data to
+partner

--- a/l10n_pe_vat_sunat_validation/__init__.py
+++ b/l10n_pe_vat_sunat_validation/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 #
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_vat_sunat_validation/__openerp__.py
+++ b/l10n_pe_vat_sunat_validation/__openerp__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 #
 #    Module Writen to OpenERP, Open Source Management Solution
 #
@@ -29,11 +29,6 @@
     "version": "1.0",
     "author": "Edgard Pimentel, Vauxoo",
     "category": "Localization\\Peru",
-    "description": """
-This module adds functionality to validate de RUC with SUNAT, and get data to
-partner
-
-""",
     "website": "http://www.vauxoo.com/",
     "license": "",
     "depends": [
@@ -48,4 +43,3 @@ partner
     "installable": True,
     "auto_install": False
 }
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/l10n_pe_vat_sunat_validation/model/__init__.py
+++ b/l10n_pe_vat_sunat_validation/model/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ##
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/l10n_pe_vat_sunat_validation/model/res_partner.py
+++ b/l10n_pe_vat_sunat_validation/model/res_partner.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 ##
 #    Module Writen to OpenERP, Open Source Management Solution
 #

--- a/opl/README.rst
+++ b/opl/README.rst
@@ -1,0 +1,15 @@
+OpenERP Peruvian Localization
+=============================
+
+
+Install all apps needed to comply with Peruvian laws
+====================================================
+This module will install for you:
+
+From git@github.com:Vauxoo/odoo-peru.git
+    l10n_pe_add_series_field
+    l10n_pe_base_vat_split
+    l10n_pe_crm_lead
+    l10n_pe_invoice
+    l10n_pe_sale
+    l10n_pe_toponyms

--- a/opl/__openerp__.py
+++ b/opl/__openerp__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-                                                       #
+# coding: utf-8
 ##
 #    Module Writen to OpenERP, Open Source Management Solution                #
 #                                                                             #
@@ -24,23 +24,11 @@
 #                                                                             #
 ##
 
-{"name": "OpenERP Peruvian Localization",
+{
+    "name": "OpenERP Peruvian Localization",
     "version": "",
     "author": "Vauxoo",
     "category": "Localization/Application",
-    "description": """
-Install all apps needed to comply with Peruvian laws
-====================================================
-This module will install for you:
-
-From git@github.com:Vauxoo/odoo-peru.git
-    l10n_pe_add_series_field
-    l10n_pe_base_vat_split
-    l10n_pe_crm_lead
-    l10n_pe_invoice
-    l10n_pe_sale
-    l10n_pe_toponyms
-    """,
     "website": "http://www.vauxoo.com",
     "license": "AGPL-3",
     "depends": [
@@ -57,4 +45,4 @@ From git@github.com:Vauxoo/odoo-peru.git
     "data": [],
     'test': [],
     "installable": True,
-    "active": False, }
+}

--- a/opl_all/README.rst
+++ b/opl_all/README.rst
@@ -1,0 +1,13 @@
+OpenERP Peruvian Localization
+=============================
+
+
+Install all apps needed to comply with Peruvian laws plus all oficial modules
+=============================================================================
+
+This module will install for you:
+
+  - OPL module
+
+  - All oficial modules (account, stock, mrp, etc.)
+

--- a/opl_all/__openerp__.py
+++ b/opl_all/__openerp__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-                                                       #
+# coding: utf-8
 ##
 #    Module Writen to OpenERP, Open Source Management Solution                #
 #                                                                             #
@@ -24,21 +24,11 @@
 #                                                                             #
 ##
 
-{"name": "OpenERP Peruvian Localization",
+{
+    "name": "OpenERP Peruvian Localization",
     "version": "",
     "author": "Vauxoo",
     "category": "Localization/Application",
-    "description": """
-Install all apps needed to comply with Peruvian laws plus all oficial modules
-=============================================================================
-
-This module will install for you:
-
-  - OPL module
-
-  - All oficial modules (account, stock, mrp, etc.)
-
-                    """,
     "website": "http://www.vauxoo.com/",
     "license": "AGPL-3",
     "depends": [
@@ -248,4 +238,4 @@ This module will install for you:
     "data": [],
     'test': [],
     "installable": True,
-    "active": False, }
+}


### PR DESCRIPTION
Standardize odoo-peru modules:
- Standardize executable files.
  - Remove magic comment interpreter (if it exists).
  - Remove execute permissions.
- Remove active key and deprecated description in manifest file.
- Add license key in manifest file.
- Delete vim comment, change coding comment and insert missing coding comment.
- Create README.md files and move them to README.rst files.